### PR TITLE
Switch to Authorization header

### DIFF
--- a/js/monitor.js
+++ b/js/monitor.js
@@ -16,6 +16,7 @@
       else console.error('getJSON status !== 200', url, request)
     }
     request.open('GET', url, true)
+    request.setRequestHeader('Authorization','token ' + config.token);
     request.send(null)
   }
 
@@ -26,9 +27,7 @@
    * @param {Function} callback
    */
   function queryGitHub (query, params, callback) {
-    getJSON('https://api.github.com' + query +
-            '?access_token=' + config.token +
-            params || '', callback)
+    getJSON('https://api.github.com' + query + '?' + params || '', callback)
   }
 
   /**


### PR DESCRIPTION
Access token in URL params is deprecated, so this will switch to Authorization header.
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters